### PR TITLE
Silence chmod() warnings

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -302,7 +302,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         $tmpFileName = $fileName . '.' . uniqid('', true);
 
         file_put_contents($tmpFileName, $proxyCode);
-        chmod($tmpFileName, 0664);
+        @chmod($tmpFileName, 0664);
         rename($tmpFileName, $fileName);
     }
 


### PR DESCRIPTION
This may be required on some filesystems, most notably in some situations when exporting via NFS into a Vagrant box. Haven't dug into details but seems to be an issue if the owner of the file is not the user trying to `chmod` (?).